### PR TITLE
Fix mkdocs issues to get the docker image to build successfully

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -122,11 +122,11 @@ wget -P /build/software/nodejs https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-
 && rm /build/software/nodejs/node-v8.8.1-linux-x64.tar.xz
 
 RUN \
-sudo apt-get -y install python-pip \
-&& sudo pip --version \
-&& sudo apt-get -y install build-essential python-dev \
-&& sudo pip install mkdocs && mkdocs --version \
-&& sudo pip install mkdocs-material
+apt-get update && apt-get -y install python-pip \
+&& pip --version \
+&& apt-get -y install build-essential python-dev \
+&& pip install mkdocs && mkdocs --version \
+&& pip install mkdocs-material
 
 ENV PATH=$PATH:/build/software/nodejs/node-v8.8.1-linux-x64/bin
 


### PR DESCRIPTION
## Purpose
>The docker file does not build properly because of the issue with mkdocs installation

## Goals
> Change Dockerfile to fix this issue

## Approach
> Change Dockerfile so that the docker image build succeeds.

## User stories
> N/A

## Release note
>  N/A

## Documentation
>  N/A

## Training
>https://docs.google.com/document/d/1BGG7ewYH6_qFaxVroe_-0p4daqiSWN6S2ooLxKpCh8I/edit#heading=h.6k92279mqu82

## Certification
> N/A

## Marketing
>  N/A

## Automation tests
 - Unit tests 
   >  N/A
 - Integration tests
   >  N/A

## Security checks
  N/A

## Samples
>  N/A

## Related PRs
>  N/A

## Migrations (if applicable)
>  N/A

## Test environment
> Mac OS 
 
## Learning
>  N/A