### PR TITLE
Add gradle and android sdk

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -130,6 +130,22 @@ sudo apt-get -y install python-pip \
 
 ENV PATH=$PATH:/build/software/nodejs/node-v8.8.1-linux-x64/bin
 
+ENV JAVA_HOME /build/software/java/jdk1.8.0_144
+
+RUN \
+wget -P /build/software/gradle https://services.gradle.org/distributions/gradle-4.2.1-bin.zip \
+&& unzip /build/software/gradle/gradle-4.2.1-bin.zip  -d /build/software/gradle/ \
+&& rm /build/software/gradle/gradle-4.2.1-bin.zip
+
+RUN \
+wget -P /build/software/android https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip \
+&&unzip /build/software/android/sdk-tools-linux-3859397.zip -d /build/software/android/ \
+&& rm /build/software/android/sdk-tools-linux-3859397.zip \
+&& yes | /build/software/android/tools/bin/sdkmanager --licenses \
+&& chmod 777 -R /build/software/android/
+
+ENV PATH=$PATH:/build/software/gradle/gradle-4.2.1/bin
+
 RUN \
 echo "net.ipv4.ip_local_port_range=15000 61000" >> /etc/sysctl.conf \
 && echo "net.ipv4.tcp_fin_timeout=30" >> /etc/sysctl.conf \


### PR DESCRIPTION
## Purpose
> Can't do a android gradle build in jenkins. 

## Goals
>  Installing Gradle and Android SDK in the Dockerfile. 

## Approach
> Install gradle in the Dockerfile
> Download and accept licences for android sdk. 

## User stories
> N/A

## Release note
>  N/A

## Documentation
>  N/A

## Training
>  N/A

## Certification
>  N/A

## Marketing
>  N/A

## Automation tests
  N/A

## Security checks
  N/A

## Samples
>  N/A

## Related PRs
>  N/A

## Migrations (if applicable)
>  N/A

## Test environment
>  N/A
 
## Learning
>  N/A