### PR TITLE
Add Golang to the wum docker file

### DIFF
--- a/wum-live-sync-automation/docker/Dockerfile
+++ b/wum-live-sync-automation/docker/Dockerfile
@@ -107,5 +107,22 @@ chmod a+x /build/software/java/jdk-6u33-linux-x64.bin \
 && echo "\n" | sh /build/software/java/jdk-6u33-linux-x64.bin \
 && rm /build/software/java/jdk-6u33-linux-x64.bin
 
+RUN mkdir -p /build/software/go
+
+RUN wget -P /build/software/go https://dl.google.com/go/go1.10.linux-amd64.tar.gz \
+    && tar -xzf /build/software/go/go1.10.linux-amd64.tar.gz --directory /build/software/go && mv /build/software/go/go /build/software/go/go-1.10 && rm /build/software/go/go1.10.linux-amd64.tar.gz
+
+RUN wget -P /build/software/go https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz \
+    && tar -xzf /build/software/go/go1.12.5.linux-amd64.tar.gz --directory /build/software/go && mv /build/software/go/go /build/software/go/go-1.12.5 && rm /build/software/go/go1.12.5.linux-amd64.tar.gz
+
+RUN wget -P /build/software/go https://dl.google.com/go/go1.13.linux-amd64.tar.gz \
+    && tar -xzf /build/software/go/go1.13.linux-amd64.tar.gz --directory /build/software/go && mv /build/software/go/go /build/software/go/go-1.13 && rm /build/software/go/go1.13.linux-amd64.tar.gz
+
+ENV GOPATH /build/software/go/go
+ENV PATH $GOPATH/bin:/build/software/go/go-1.12.5/bin:$PATH
+ENV PATH $GOPATH/bin:/build/software/go/go-1.13/bin:$PATH
+RUN mkdir -p "$GOPATH/src/github.com/wso2-support" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN curl https://glide.sh/get | sh
+
 RUN \
 apt-get update && apt-get install -y zip


### PR DESCRIPTION
## Purpose
> Install the golang versions 1.10, 1.12.5 and 1.13 to the jenkins slave docker image.

## Goals
> Enable products that require Golang to be build in the jenkins server

