### PR TITLE
Update documentation of nexus-migration scripts

### DIFF
--- a/nexus-migration/auto-nexus-staging-promotion/README.md
+++ b/nexus-migration/auto-nexus-staging-promotion/README.md
@@ -1,6 +1,6 @@
 # Automated Promotion Pipeline from Staging to Releases and Maven Central
 
-A Jenkins Declarative Pipeline that automatically promotes **all** Maven artifacts found in a Nexus staging repository to **Maven Central** on a scheduled basis (every 6 hours). No user input is required — the pipeline discovers, downloads, moves, and uploads everything autonomously. A human then confirms or drops the deployment on the Central Publisher Portal.
+A Jenkins Declarative Pipeline that automatically promotes **all** Maven artifacts found in a Nexus 'staging' repository to Nexus 'releases and **Central Publisher Portal** on a scheduled basis (every 6 hours). The pipeline discovers, downloads, moves, and uploads everything. Thereafter the Admin then confirms publishing to **Maven Central** or drops the deployment on the Central Publisher Portal.
 
 ## Workflow
 
@@ -13,7 +13,7 @@ Nexus Staging  ──(discover)──▶  Jenkins Agent
                                       │
                                (maven-central.sh)
                                       │
-                               Central Publisher Portal  ──(human action)──▶  Maven Central
+                               Central Publisher Portal  ──(admin's action)──▶  Maven Central
 ```
 
 1. **Discover Staging Components** — paginates the Nexus `/v1/search` API to collect every unique `group:name:version` tuple present in the staging repository. If nothing is found the pipeline exits cleanly.
@@ -34,7 +34,7 @@ Adjust the `triggers { cron(...) }` block to change the frequency.
 
 ## Publishing Mode
 
-The pipeline always uses `CENTRAL_PUBLISHING_TYPE=USER_MANAGED`. Artifacts are **validated and held** on the Portal; a human must visit [central.sonatype.com/publishing/deployments](https://central.sonatype.com/publishing/deployments) to publish or drop each deployment. Change to `AUTOMATIC` if you want artifacts released immediately without manual confirmation.
+The pipeline always uses `CENTRAL_PUBLISHING_TYPE=USER_MANAGED`. Artifacts are **validated and held** on the Portal; the admin must visit [central.sonatype.com/publishing/deployments](https://central.sonatype.com/publishing/deployments) to publish or drop each deployment. Change to `AUTOMATIC` if you want artifacts released immediately without manual confirmation.
 
 ## Required Jenkins Credentials
 

--- a/nexus-migration/auto-nexus-staging-promotion/README.md
+++ b/nexus-migration/auto-nexus-staging-promotion/README.md
@@ -1,6 +1,6 @@
 # Automated Promotion Pipeline from Staging to Releases and Maven Central
 
-A Jenkins Declarative Pipeline that automatically promotes **all** Maven artifacts found in a Nexus 'staging' repository to Nexus 'releases and **Central Publisher Portal** on a scheduled basis (every 6 hours). The pipeline discovers, downloads, moves, and uploads everything. Thereafter the Admin then confirms publishing to **Maven Central** or drops the deployment on the Central Publisher Portal.
+A Jenkins Declarative Pipeline that automatically promotes **all** Maven artifacts found in a Nexus 'staging' repository to Nexus 'releases' and **Central Publisher Portal** on a scheduled basis (every 6 hours). The pipeline discovers, downloads, moves, and uploads everything. Thereafter the Admin then confirms publishing to **Maven Central** or drops the deployment on the Central Publisher Portal.
 
 ## Workflow
 

--- a/nexus-migration/manual-nexus-staging-promotion/README.md
+++ b/nexus-migration/manual-nexus-staging-promotion/README.md
@@ -1,6 +1,6 @@
 # Promote Staging to Releases and Maven Central
 
-A Jenkins Declarative Pipeline that promotes Maven artifacts from a **Nexus staging repository** directly to **Maven Central**. This pipeline is used for artifacts that were already released to Nexus staging and need to be published to Maven Central or Central Publisher Portal without triggering a new Maven release build.
+A Jenkins Declarative Pipeline that promotes Maven artifacts from a Nexus 'staging' repository to Nexus 'releases' repository and **Central Publisher Portal**. This pipeline is used for artifacts that were already published to Nexus 'staging' and need to be propagate to Nexus 'releases' and Central Publisher Portal manually.
 
 ## Workflow
 

--- a/nexus-migration/manual-nexus-staging-promotion/README.md
+++ b/nexus-migration/manual-nexus-staging-promotion/README.md
@@ -1,6 +1,6 @@
 # Promote Staging to Releases and Maven Central
 
-A Jenkins Declarative Pipeline that promotes Maven artifacts from a Nexus 'staging' repository to Nexus 'releases' repository and **Central Publisher Portal**. This pipeline is used for artifacts that were already published to Nexus 'staging' and need to be propagate to Nexus 'releases' and Central Publisher Portal manually.
+A Jenkins Declarative Pipeline that promotes Maven artifacts from a Nexus 'staging' repository to Nexus 'releases' repository and **Central Publisher Portal**. This pipeline is used for artifacts that were already published to Nexus 'staging' and need to be propagated to Nexus 'releases' and Central Publisher Portal manually.
 
 ## Workflow
 

--- a/nexus-migration/manual-nexus-staging-promotion/nexus-promotion.groovy
+++ b/nexus-migration/manual-nexus-staging-promotion/nexus-promotion.groovy
@@ -22,7 +22,7 @@
 // Workflow:
 //   1. Move artifact from Nexus staging → releases repository
 //   2. Download all artifacts from Nexus releases (Maven repo layout)
-//   3. Publish to Maven Central via maven-central.sh
+//   3. Publish to Maven Central (USER_MANAGED — admin confirms on Publisher Portal)
 //
 // Required Jenkins credentials:
 //   nexus-deployer-credentials   : Username/Password  – Nexus user with staging move rights

--- a/nexus-migration/nexus-import-export-confs/README.md
+++ b/nexus-migration/nexus-import-export-confs/README.md
@@ -1,6 +1,6 @@
 # Nexus Security Configuration Migration
 
-A Bash script for exporting and importing **Nexus Repository security configuration** between Nexus instances. Supports content selectors, privileges, and roles — useful when migrating from one Nexus version to another (tested: Nexus Repository Pro 3.66.x → 3.82.x).
+A Bash script for exporting and importing **Nexus Repository security configuration** between Nexus instances. Supports content selectors, privileges, and roles. It is useful when migrating from one Nexus version to another (tested: Nexus Repository Pro 3.66.x → 3.82.x).
 
 ## Supported Objects
 

--- a/nexus-migration/nexus-publish/README.md
+++ b/nexus-migration/nexus-publish/README.md
@@ -1,6 +1,6 @@
 # Publish to Nexus 3
 
-A Bash script that uploads Maven release artifacts to a **Nexus Repository 3** instance via its REST API. It is registered as a **Jenkins Managed Script** and executed as a post-build step inside a **Maven Build Project** that uses the **M2 Release Plugin**.
+A Bash script that uploads Maven release artifacts to a **Nexus 3 Repository** instance via its REST API. It is registered as a **Jenkins Managed Script** and executed as a post-build step inside a **Maven Build Project** that uses the **M2 Release Plugin**.
 
 ## How It Works
 

--- a/nexus-migration/update-build-jobs/README.md
+++ b/nexus-migration/update-build-jobs/README.md
@@ -1,6 +1,6 @@
 # Update Maven Build Job Configurations
 
-A Jenkins Script Console Groovy script that **bulk-updates existing Maven/FreeStyle Jenkins jobs** to add the configuration required for publishing to Maven Central alongside the existing Nexus workflow. Run it once during the migration to avoid manually editing every job.
+A Jenkins Script Console Groovy script that **bulk-updates existing Maven Build Jenkins jobs** to add the configuration required for publishing to Nexus 3 and Maven Central. 
 
 ## What It Does
 

--- a/nexus-migration/update-build-jobs/update-build-jobs.groovy
+++ b/nexus-migration/update-build-jobs/update-build-jobs.groovy
@@ -45,7 +45,7 @@ import org.jenkinsci.plugins.managedscripts.ScriptBuildStep
 
 // Mode: "single" to update one job, "folder" to update all
 //       Maven-Release jobs inside a Jenkins folder (by full path).
-def MODE = "folder"   // "single" | "folder"
+def MODE = "folder"   // "single" | "folder" | "list"
 
 // Full job path for single-job mode  (e.g. "my-folder/my-job")
 def SINGLE_JOB_NAME = "test-jobs/maven-tester-support"


### PR DESCRIPTION
## Purpose

This pull request updates documentation and scripts related to Nexus and Maven Central publishing workflows to clarify the promotion process, terminology, and supported modes. The changes focus on improving clarity about the roles involved, the repositories targeted, and the manual steps required for publishing, as well as expanding script options for job updates.

**Documentation and workflow clarification:**

* Updated `README.md` files for the automated and manual Nexus staging promotion pipelines to clarify that artifacts are first promoted from Nexus 'staging' to 'releases' and then to the Central Publisher Portal, with final publishing to Maven Central requiring admin confirmation. The descriptions now consistently refer to the correct repositories and clarify the admin's role in the process. [[1]](diffhunk://#diff-762754ca15e84145ac7e292ee8dbcdb04873815c0e54620d54f0fdd9c61ce65eL3-R3) [[2]](diffhunk://#diff-762754ca15e84145ac7e292ee8dbcdb04873815c0e54620d54f0fdd9c61ce65eL16-R16) [[3]](diffhunk://#diff-762754ca15e84145ac7e292ee8dbcdb04873815c0e54620d54f0fdd9c61ce65eL37-R37) [[4]](diffhunk://#diff-7898706b7de04dd855206d307f2a19d86a50b5b80e9637b3043e2cb20af3b312L3-R3)
* Revised workflow comments in `nexus-promotion.groovy` to specify that publishing to Maven Central is done in USER_MANAGED mode, requiring admin confirmation on the Publisher Portal.

**General documentation improvements:**

* Improved clarity and grammar in the `nexus-import-export-confs/README.md` and `nexus-publish/README.md` files, including consistent repository naming and explanation of script usage. [[1]](diffhunk://#diff-ba4895a2338f4dfa42f6777fb670be666b3d8807e1dba161bbaa6f0a51691cacL3-R3) [[2]](diffhunk://#diff-c726ac83084187f6514f73d3fdb85313baa4ad69730fa52b21b180d54721e61cL3-R3)
* Updated the `update-build-jobs/README.md` to clarify that the script updates jobs for publishing to both Nexus 3 and Maven Central, and reworded for accuracy.

**Script enhancements:**

* Added a new `"list"` mode to the `MODE` variable in `update-build-jobs.groovy`, allowing for additional flexibility in how jobs are selected for updates.